### PR TITLE
Fix error if IDL does not contain `types` field

### DIFF
--- a/app/type-generator.tsx
+++ b/app/type-generator.tsx
@@ -30,7 +30,7 @@ interface Type {
 }
 
 interface JSONData {
-  types: Type[];
+  types?: Type[];
   accounts: Type[];
 }
 
@@ -129,7 +129,7 @@ export function generateTypeScriptTypes({
 }): string {
   const typeScriptTypes: string[] = []
 
-  if (includeTypes) {
+  if (includeTypes && jsonData.types) {
     for (const type of jsonData.types) {
       const typeName = type.name
       const typeDefinition = type.type
@@ -144,7 +144,7 @@ export function generateTypeScriptTypes({
     }
   }
 
-  if (includeEnums) {
+  if (includeEnums && jsonData.types) {
     for (const type of jsonData.types) {
       const typeName = type.name
       const typeDefinition = type.type


### PR DESCRIPTION
An IDL isn't guaranteed to have a top-level `types` field. This PR fixes the error from trying to map over that field if it is not present.

This avoids an error if "include types" or "include enums" is selected but the IDL doesn't contain any 

Fixes #2 