### PR TITLE
Add support for generating types for events

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,6 +34,7 @@ export default function IndexPage() {
   const [includeAccounts, setIncludeAccounts] = useState<CheckedState>(false);
   const [includeTypes, setIncludeTypes] = useState<CheckedState>(true);
   const [includeEnums, setIncludeEnums] = useState<CheckedState>(true);
+  const [includeEvents, setIncludeEvents] = useState<CheckedState>(true);
 
   return (
     <section className="container grid items-center gap-6 pb-8 pt-6 md:py-10">
@@ -122,6 +123,15 @@ export default function IndexPage() {
                 Include Enums
               </label>
             </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox id="terms2" checked={includeEvents} onCheckedChange={setIncludeEvents} />
+              <label
+                htmlFor="terms2"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                Include Events
+              </label>
+            </div>
           </div>
         </div>
         <div className="flex items-center justify-start space-x-4 pt-2">
@@ -153,6 +163,7 @@ export default function IndexPage() {
                   includeAccounts: includeAccounts === true,
                   includeTypes: includeTypes === true,
                   includeEnums: includeEnums === true,
+                  includeEvents: includeEvents === true,
                   useBigNumberForBN: useBigNumberForBN === true,
                 })
                 setTypes(types)

--- a/app/type-generator.tsx
+++ b/app/type-generator.tsx
@@ -29,9 +29,15 @@ interface Type {
   type: TypeDefinition;
 }
 
+interface Event {
+  name: string;
+  fields: TypeField[]
+}
+
 interface JSONData {
   types: Type[];
   accounts: Type[];
+  events?: Event[];
 }
 
 const typeMap = [
@@ -169,6 +175,23 @@ export function generateTypeScriptTypes({
         useBigNumberForBN
       )
       typeScriptTypes.push(`interface ${typeName} ${typeScriptType}`)
+    }
+  }
+
+  // TODO: includeEvents
+  if (jsonData.events) {
+    for (const event of jsonData.events) {
+      const typeName = event.name
+      const typeDefinition: TypeDefinition = {
+        kind: 'struct',
+        fields: event.fields
+      }
+      const typescriptType = generateTypeScriptType(
+        typeDefinition,
+        useNumberForBN,
+        useBigNumberForBN
+      )
+      typeScriptTypes.push(`interface ${typeName} ${typescriptType}`)
     }
   }
 

--- a/app/type-generator.tsx
+++ b/app/type-generator.tsx
@@ -124,6 +124,7 @@ export function generateTypeScriptTypes({
   includeAccounts,
   includeTypes,
   includeEnums,
+  includeEvents,
   useBigNumberForBN,
 }: {
   jsonData: JSONData
@@ -131,6 +132,7 @@ export function generateTypeScriptTypes({
   includeAccounts: boolean
   includeTypes: boolean
   includeEnums: boolean,
+  includeEvents: boolean,
   useBigNumberForBN: boolean
 }): string {
   const typeScriptTypes: string[] = []
@@ -178,8 +180,7 @@ export function generateTypeScriptTypes({
     }
   }
 
-  // TODO: includeEvents
-  if (jsonData.events) {
+  if (includeEvents && jsonData.events) {
     for (const event of jsonData.events) {
       const typeName = event.name
       const typeDefinition: TypeDefinition = {


### PR DESCRIPTION
This PR adds support for generating types for the events in an IDL. It adds a new optional checkbox to enable/disable this feature, and does not error if enabled for an IDL with no events

Example event in IDL:

```json
  "events": [
    {
      "name": "PixelChanged",
      "fields": [
        {
          "name": "posX",
          "type": "u8",
          "index": false
        },
        {
          "name": "posY",
          "type": "u8",
          "index": false
        },
        {
          "name": "colR",
          "type": "u8",
          "index": false
        },
        {
          "name": "colG",
          "type": "u8",
          "index": false
        },
        {
          "name": "colB",
          "type": "u8",
          "index": false
        }
      ]
    }
  ]
```

This will generate the type:

```ts
interface PixelChanged {
   posX: number;
   posY: number;
   colR: number;
   colG: number;
   colB: number;
}
```

Screenshot:

<img width="1368" alt="Screenshot 2023-09-18 at 12 19 28" src="https://github.com/SolWorks-Dev/idl-to-typescript-generator/assets/1711350/376a2926-c483-4095-ae68-bddb41497e8b">
